### PR TITLE
Fix #38

### DIFF
--- a/BulkExtensions.Shared/Helpers/SqlHelper.cs
+++ b/BulkExtensions.Shared/Helpers/SqlHelper.cs
@@ -197,11 +197,13 @@ namespace EntityFramework.BulkExtensions.Commons.Helpers
 
         internal static string BuildMergeOutputSet(string outputTableName, IEnumerable<IPropertyMapping> properties)
         {
-            var propertyMappings = properties as IList<IPropertyMapping> ?? properties.ToList();
+            var propertyMappings = (properties as IList<IPropertyMapping> ?? properties.ToList())
+                .Where(x=>!x.IsCt);
             var insertedColumns = string.Join(", ", propertyMappings.Select(property => $"INSERTED.{property.ColumnName}"));
             var outputColumns = string.Join(", ", propertyMappings.Select(property => property.ColumnName));
+            var insertedColumnDelimiter = propertyMappings.Any() ? ", " : String.Empty;
 
-            return $" OUTPUT {Source}.{Identity}, {insertedColumns} INTO {outputTableName} ({Identity}, {outputColumns})";
+            return $" OUTPUT {Source}.{Identity}{insertedColumnDelimiter}{insertedColumns} INTO {outputTableName} ({Identity}{insertedColumnDelimiter}{outputColumns})";
         }
 
         /// <summary>

--- a/BulkExtensions.Shared/Mapping/IPropertyMapping.cs
+++ b/BulkExtensions.Shared/Mapping/IPropertyMapping.cs
@@ -6,6 +6,7 @@
         string ColumnName { get; }
         bool IsPk { get; }
         bool IsFk { get; }
+        bool IsCt { get; }
         bool IsHierarchyMapping { get; }
         bool IsDbGenerated { get; }
     }

--- a/BulkExtensions.Shared/Mapping/PropertyMapping.cs
+++ b/BulkExtensions.Shared/Mapping/PropertyMapping.cs
@@ -6,6 +6,7 @@
         public string ColumnName { get; set; }
         public bool IsPk { get; set; }
         public bool IsFk { get; set; }
+        public bool IsCt { get; set; }
         public bool IsHierarchyMapping { get; set; }
         public bool IsDbGenerated { get; set; }
     }

--- a/EntityFramework.BulkExtensions/Mapping/MappingExtension.cs
+++ b/EntityFramework.BulkExtensions/Mapping/MappingExtension.cs
@@ -113,7 +113,8 @@ namespace EntityFramework.BulkExtensions.Mapping
                     PropertyName = propertyMapping.Property.Name,
                     IsPk = ((EntityType)propertyMapping.Column.DeclaringType).KeyProperties
                         .Any(property => property.Name.Equals(propertyMapping.Column.Name)),
-                    IsDbGenerated = propertyMapping.Column.IsStoreGeneratedIdentity
+                    IsCt = propertyMapping.Column.PrimitiveType.Name == "rowversion" || propertyMapping.Column.PrimitiveType.Name == "timestamp",
+                    IsDbGenerated = propertyMapping.Column.IsStoreGeneratedIdentity                    
                     || propertyMapping.Column.IsStoreGeneratedComputed
                 });
 

--- a/EntityFrameworkCore.BulkExtensions.NetStandard/Mapping/MappingExtension.cs
+++ b/EntityFrameworkCore.BulkExtensions.NetStandard/Mapping/MappingExtension.cs
@@ -72,6 +72,7 @@ namespace EntityFramework.BulkExtensions.Mapping
                     ColumnName = property.Relational().ColumnName,
                     IsPk = property.IsPrimaryKey(),
                     IsFk = property.IsForeignKey(),
+                    IsCt = property.IsConcurrencyToken,
                     IsDbGenerated = property.ValueGenerated != ValueGenerated.Never
                 });
         }

--- a/EntityFrameworkCore.BulkExtensions/Mapping/MappingExtension.cs
+++ b/EntityFrameworkCore.BulkExtensions/Mapping/MappingExtension.cs
@@ -72,6 +72,7 @@ namespace EntityFramework.BulkExtensions.Mapping
                     ColumnName = property.Relational().ColumnName,
                     IsPk = property.IsPrimaryKey(),
                     IsFk = property.IsForeignKey(),
+                    IsCt = property.IsConcurrencyToken,
                     IsDbGenerated = property.ValueGenerated != ValueGenerated.Never
                 });
         }

--- a/UnitTests.EF6/BulkInsertTests/EF6_ConcurrencyTokenBulkInsert.cs
+++ b/UnitTests.EF6/BulkInsertTests/EF6_ConcurrencyTokenBulkInsert.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EntityFramework.BulkExtensions;
+using UnitTests.EF6.Database;
+using UnitTests.EF6.Helpers;
+using UnitTests.EF6.Model;
+using Xunit;
+
+namespace UnitTests.EF6.BulkInsertTests
+{
+    public class EF6_ConcurrencyTokenBulkInsert : IDisposable
+    {
+        private readonly TestDatabase _context;
+        private readonly IList<ConcurrencyTokenEntity> _collection;
+
+        public EF6_ConcurrencyTokenBulkInsert()
+        {
+            _context = new TestDatabase();
+            ClearTable();
+            _collection = new List<ConcurrencyTokenEntity>();
+            for (var i = 0; i < 10; i++)
+            {
+                _collection.Add(new ConcurrencyTokenEntity
+                {
+                    Name = Helper.RandomString(10)
+                });
+            }
+        }
+
+        #region No Options Set
+
+        [Fact]
+        public void TestAffectedRowsCount()
+        {
+            var rowsCount = _context.BulkInsert(_collection);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertedEntitiesCount()
+        {
+            _context.BulkInsert(_collection);
+            var savedEntities = _context.ConcurrencyTokenEntity.ToList();
+            Assert.Equal(savedEntities.Count, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly()
+        {
+            _context.BulkInsert(_collection);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            for (var i = 0; i < _collection.Count; i++)
+            {
+                var entity = _collection[i];
+                var savedEntity = savedEntities[i];
+                Assert.NotEqual(entity.Id, savedEntity.Id);
+                Assert.Equal(entity.Name, savedEntity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        #region Output Identity Set
+
+        [Fact]
+        public void TestAffectedRowsCount_OutputIdentity()
+        {
+            var rowsCount = _context.BulkInsert(_collection, InsertOptions.OutputIdentity);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly_OutputIdentity()
+        {
+            _context.BulkInsert(_collection, InsertOptions.OutputIdentity);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            foreach (var entity in _collection)
+            {
+                var savedEntity = savedEntities.SingleOrDefault(saved => saved.Id.Equals(entity.Id));
+                Assert.NotNull(savedEntity);
+                Assert.Equal(entity.Name, savedEntity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        #region Output Computed Set
+
+        [Fact]
+        public void TestAffectedRowsCount_OutputComputed()
+        {
+            var rowsCount = _context.BulkInsert(_collection, InsertOptions.OutputComputed);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly_OutputComputed()
+        {
+            _context.BulkInsert(_collection, InsertOptions.OutputComputed);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            for (var i = 0; i < _collection.Count; i++)
+            {
+                var entity = _collection[i];
+                var savedEntity = savedEntities[i];
+                Assert.NotEqual(entity.Id, savedEntity.Id);
+                Assert.Equal(savedEntity.Name, entity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        #region Output Identity & Computed Set
+
+        [Fact]
+        public void TestAffectedRowsCount_OutputIdentityComputed()
+        {
+            var rowsCount = _context.BulkInsert(_collection,
+                InsertOptions.OutputIdentity | InsertOptions.OutputComputed);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly_OutputIdentityComputed()
+        {
+            _context.BulkInsert(_collection, InsertOptions.OutputIdentity | InsertOptions.OutputComputed);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            foreach (var entity in _collection)
+            {
+                var savedEntity = savedEntities.SingleOrDefault(saved => saved.Id.Equals(entity.Id));
+                Assert.NotNull(savedEntity);
+                Assert.Equal(entity.Name, savedEntity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        public void Dispose()
+        {
+            ClearTable();
+        }
+
+        private void ClearTable()
+        {
+            _context.ConcurrencyTokenEntity.RemoveRange(_context.ConcurrencyTokenEntity.ToList());
+            _context.SaveChanges();
+        }
+    }
+}

--- a/UnitTests.EF6/Database/TestDatabase.cs
+++ b/UnitTests.EF6/Database/TestDatabase.cs
@@ -20,6 +20,7 @@ namespace UnitTests.EF6.Database
         public DbSet<NotIncrementIdEntity> NotIncrementIdEntity { get; set; }
         public DbSet<ComputedEntity> ComputedEntity { get; set; }
         public DbSet<IdentityOnlyAutoEntity> IdentityOnlyAutoEntity { get; set; }
+        public DbSet<ConcurrencyTokenEntity> ConcurrencyTokenEntity { get; set; }
         public DbSet<IdentityOnlyEntity> IdentityOnlyEntity { get; set; }
 
         protected override void OnModelCreating(DbModelBuilder modelBuilder)

--- a/UnitTests.EF6/Model/ConcurrencyTokenEntity.cs
+++ b/UnitTests.EF6/Model/ConcurrencyTokenEntity.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace UnitTests.EF6.Model
+{
+    public class ConcurrencyTokenEntity
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+        
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
+    }
+}

--- a/UnitTests.NetStandard/BulkInsertTests/NetStandard_ConcurrencyTokenBulkInsert.cs
+++ b/UnitTests.NetStandard/BulkInsertTests/NetStandard_ConcurrencyTokenBulkInsert.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EntityFramework.BulkExtensions;
+using UnitTests.NetStandard.Database;
+using UnitTests.NetStandard.Helpers;
+using UnitTests.NetStandard.Model;
+using Xunit;
+
+namespace UnitTests.NetStandard.BulkInsertTests
+{
+    public class NetStandard_ConcurrencyTokenBulkInsert : IDisposable
+    {
+        private readonly TestDatabase _context;
+        private readonly IList<ConcurrencyTokenEntity> _collection;
+
+        public NetStandard_ConcurrencyTokenBulkInsert()
+        {
+            _context = new TestDatabase();
+            ClearTable();
+            _collection = new List<ConcurrencyTokenEntity>();
+            for (var i = 0; i < 10; i++)
+            {
+                _collection.Add(new ConcurrencyTokenEntity
+                {
+                    Name = Helper.RandomString(10)
+                });
+            }
+        }
+
+        #region No Options Set
+
+        [Fact]
+        public void TestAffectedRowsCount()
+        {
+            var rowsCount = _context.BulkInsert(_collection);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertedEntitiesCount()
+        {
+            _context.BulkInsert(_collection);
+            var savedEntities = _context.ConcurrencyTokenEntity.ToList();
+            Assert.Equal(savedEntities.Count, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly()
+        {
+            _context.BulkInsert(_collection);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            for (var i = 0; i < _collection.Count; i++)
+            {
+                var entity = _collection[i];
+                var savedEntity = savedEntities[i];
+                Assert.NotEqual(entity.Id, savedEntity.Id);
+                Assert.Equal(entity.Name, savedEntity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        #region Output Identity Set
+
+        [Fact]
+        public void TestAffectedRowsCount_OutputIdentity()
+        {
+            var rowsCount = _context.BulkInsert(_collection, InsertOptions.OutputIdentity);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly_OutputIdentity()
+        {
+            _context.BulkInsert(_collection, InsertOptions.OutputIdentity);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            foreach (var entity in _collection)
+            {
+                var savedEntity = savedEntities.SingleOrDefault(saved => saved.Id.Equals(entity.Id));
+                Assert.NotNull(savedEntity);
+                Assert.Equal(entity.Name, savedEntity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        #region Output Computed Set
+
+        [Fact]
+        public void TestAffectedRowsCount_OutputComputed()
+        {
+            var rowsCount = _context.BulkInsert(_collection, InsertOptions.OutputComputed);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly_OutputComputed()
+        {
+            _context.BulkInsert(_collection, InsertOptions.OutputComputed);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            for (var i = 0; i < _collection.Count; i++)
+            {
+                var entity = _collection[i];
+                var savedEntity = savedEntities[i];
+                Assert.NotEqual(entity.Id, savedEntity.Id);
+                Assert.Equal(savedEntity.Name, entity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        #region Output Identity & Computed Set
+
+        [Fact]
+        public void TestAffectedRowsCount_OutputIdentityComputed()
+        {
+            var rowsCount = _context.BulkInsert(_collection,
+                InsertOptions.OutputIdentity | InsertOptions.OutputComputed);
+            Assert.Equal(rowsCount, _collection.Count);
+        }
+
+        [Fact]
+        public void TestInsertValuesSavedCorrectly_OutputIdentityComputed()
+        {
+            _context.BulkInsert(_collection, InsertOptions.OutputIdentity | InsertOptions.OutputComputed);
+            var savedEntities = _context.ConcurrencyTokenEntity
+                .ToList();
+
+            Assert.Equal(savedEntities.Count, _collection.Count);
+
+            foreach (var entity in _collection)
+            {
+                var savedEntity = savedEntities.SingleOrDefault(saved => saved.Id.Equals(entity.Id));
+                Assert.NotNull(savedEntity);
+                Assert.Equal(entity.Name, savedEntity.Name);
+                Assert.NotEqual(savedEntity.RowVersion, entity.RowVersion);
+            }
+        }
+
+        #endregion
+
+        public void Dispose()
+        {
+            ClearTable();
+        }
+
+        private void ClearTable()
+        {
+            _context.ConcurrencyTokenEntity.RemoveRange(_context.ConcurrencyTokenEntity.ToList());
+            _context.SaveChanges();
+        }
+    }
+}

--- a/UnitTests.NetStandard/Database/TestDatabase.cs
+++ b/UnitTests.NetStandard/Database/TestDatabase.cs
@@ -12,14 +12,15 @@ namespace UnitTests.NetStandard.Database
         public DbSet<CompositeKeyEntity> CompositeKeyEntity { get; set; }
         public DbSet<CustomSchemaEntity> CustomSchemaEntities { get; set; }
         public DbSet<NotIncrementIdEntity> NotIncrementIdEntity { get; set; }
+        public DbSet<ConcurrencyTokenEntity> ConcurrencyTokenEntity { get; set; }
         public DbSet<ComputedEntity> ComputedEntity { get; set; }
         public DbSet<IdentityOnlyAutoEntity> IdentityOnlyAutoEntity { get; set; }
         public DbSet<IdentityOnlyEntity> IdentityOnlyEntity { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-//            optionsBuilder.UseSqlServer(
-//                @"Data Source=tcp:192.168.0.142,1433;Initial Catalog=UnitTests;User ID=sa;Password=sa;");
+            //            optionsBuilder.UseSqlServer(
+            //                @"Data Source=tcp:192.168.0.142,1433;Initial Catalog=UnitTests;User ID=sa;Password=sa;");
             optionsBuilder.UseSqlServer(
                 @"Data Source=tcp:10.0.0.192,1433;Initial Catalog=UnitTests;User ID=sa;Password=sa;");
         }

--- a/UnitTests.NetStandard/Model/ConcurrencyTokenEntity.cs
+++ b/UnitTests.NetStandard/Model/ConcurrencyTokenEntity.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace UnitTests.NetStandard.Model
+{
+    public class ConcurrencyTokenEntity
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
+    }
+}


### PR DESCRIPTION
Exclude concurrency tokens from the merge output, preventing an attempted failed insert.

