### PR TITLE
Sign Assemblies only in Release build configuration

### DIFF
--- a/EntityFramework.BulkExtensions/EntityFramework.BulkExtensions.csproj
+++ b/EntityFramework.BulkExtensions/EntityFramework.BulkExtensions.csproj
@@ -30,11 +30,7 @@
     <DefineConstants>EF6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
     <AssemblyOriginatorKeyFile>EntityFramework.BulkExtensions.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/EntityFrameworkCore.BulkExtensions.NetStandard/EntityFrameworkCore.BulkExtensions.NetStandard.csproj
+++ b/EntityFrameworkCore.BulkExtensions.NetStandard/EntityFrameworkCore.BulkExtensions.NetStandard.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>EntityFramework.BulkExtensions.EFCore</AssemblyTitle>
     <Description>Bulk operations extension library for Entity Framework.</Description>
     <Copyright>Copyright © Tiago L. da Nóbrega 2017</Copyright>
-    <SignAssembly>True</SignAssembly>
+    <SignAssembly Condition=" '$(Configuration)' == 'Release' ">True</SignAssembly>
     <AssemblyOriginatorKeyFile>EntityFramework.BulkExtensions.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
   </PropertyGroup>

--- a/EntityFrameworkCore.BulkExtensions/EntityFrameworkCore.BulkExtensions.csproj
+++ b/EntityFrameworkCore.BulkExtensions/EntityFrameworkCore.BulkExtensions.csproj
@@ -31,11 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
     <AssemblyOriginatorKeyFile>EntityFramework.BulkExtensions.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
After repository is cloned, developers need to create pfx certificates to sign assemblies to make build successful. 

This is additional manual work which could be workarounded by signing only Release builds which should be packed to nuget package.