### PR TITLE
Use LocalDB in unittests

### DIFF
--- a/UnitTests.EF6/App.config
+++ b/UnitTests.EF6/App.config
@@ -9,6 +9,7 @@
       <add name="TestDatabase" providerName="System.Data.SqlClient" connectionString="Data Source=192.168.0.142,1433;Network Library=DBMSSOCN;Initial Catalog=UnitTests;User ID=sa;Password=sa;"/>
       <add name="TestDatabaseWork" providerName="System.Data.SqlClient" connectionString="Data Source=10.0.0.194,1433;Network Library=DBMSSOCN;Initial Catalog=UnitTests;User ID=sa;Password=sa;"/>
       <add name="TestDatabaseLocal" connectionString="data source=.\SQLEXPRESS; Integrated Security=SSPI; initial catalog=UnitTests" providerName="System.Data.SqlClient" />
+      <add name="TestDatabaseLocalDB" connectionString="data source=(localdb)\MSSQLLocalDB; Integrated Security=SSPI; initial catalog=BulkExtensions_UnitTests" providerName="System.Data.SqlClient" />
     </connectionStrings>
 
     <entityFramework>

--- a/UnitTests.EF6/Database/TestDatabase.cs
+++ b/UnitTests.EF6/Database/TestDatabase.cs
@@ -7,7 +7,7 @@ namespace UnitTests.EF6.Database
     public class TestDatabase : DbContext
     {
 
-        public TestDatabase() : base("TestDatabaseLocal")
+        public TestDatabase() : base("TestDatabaseLocalDB")
         {
         }
         

--- a/UnitTests.NetStandard/Database/TestDatabase.cs
+++ b/UnitTests.NetStandard/Database/TestDatabase.cs
@@ -18,10 +18,8 @@ namespace UnitTests.NetStandard.Database
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-//            optionsBuilder.UseSqlServer(
-//                @"Data Source=tcp:192.168.0.142,1433;Initial Catalog=UnitTests;User ID=sa;Password=sa;");
             optionsBuilder.UseSqlServer(
-                @"Data Source=tcp:10.0.0.192,1433;Initial Catalog=UnitTests;User ID=sa;Password=sa;");
+                @"data source=(localdb)\MSSQLLocalDB; Integrated Security=SSPI; initial catalog=BulkExtensions_UnitTests");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
Unittest projects have several connectionstrings. Connection string that is used points to local SQL Express instance, which might not be present on dev boxes.

On a very high level, LocalDB is [dev version](https://blogs.msdn.microsoft.com/jerrynixon/2012/02/26/sql-express-v-localdb-v-sql-compact-edition/) of SQL Express. It is bundled into VisualStudio installation package and since VS 2015 it has constant name - MSSQLLocalDB.